### PR TITLE
- Moved all packages that should be devDependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,13 @@
   "scripts": {
     "build": "webpack",
     "dev": "webpack-dev-server --open",
+    "heroku-prebuild": "export NPM_CONFIG_PRODUCTION=false; export NODE_ENV=development; npm install",
+    "heroku-postbuild": "export NPM_CONFIG_PRODUCTION=true; export NODE_ENV=production;",
     "lint": "tslint --config ./tslint.json --project tsconfig.json",
     "postinstall": "npm run build",
     "setup": "node ./script/directory-structure.js",
-    "test": "karma start karma.conf.js",
-    "test:watch": "karma start karma.conf.js --no-single-run --auto-watch"
+    "test:watch": "karma start karma.conf.js --no-single-run --auto-watch",
+    "test": "karma start karma.conf.js"
   },
   "repository": {
     "type": "git",
@@ -29,28 +31,28 @@
   ],
   "devDependencies": {
     "@types/jasmine": "^2.8.6",
-    "jasmine-core": "^2.99.0",
-    "karma": "^1.7.1",
-    "karma-chrome-launcher": "^2.2.0",
-    "karma-jasmine": "^1.1.1",
-    "karma-typescript": "^3.0.12",
-    "tslint": "^5.9.1",
-    "tslint-microsoft-contrib": "^5.0.3"
-  },
-  "dependencies": {
     "autoprefixer": "^7.2.5",
     "awesome-typescript-loader": "^3.4.1",
     "bootstrap": "^4.1.1",
     "css-loader": "^0.28.9",
     "extract-text-webpack-plugin": "^3.0.2",
-    "http-server": "^0.11.1",
+    "jasmine-core": "^2.99.0",
+    "karma-chrome-launcher": "^2.2.0",
+    "karma-jasmine": "^1.1.1",
+    "karma-typescript": "^3.0.12",
+    "karma": "^1.7.1",
     "node-sass": "^4.7.2",
     "postcss-loader": "^2.0.10",
     "sass-loader": "^6.0.6",
     "source-map-loader": "^0.2.3",
     "style-loader": "^0.20.1",
+    "tslint-microsoft-contrib": "^5.0.3",
+    "tslint": "^5.9.1",
     "typescript": "^2.7.1",
-    "webpack": "^3.10.0",
-    "webpack-dev-server": "^2.11.1"
+    "webpack-dev-server": "^2.11.1",
+    "webpack": "^3.10.0"
+  },
+  "dependencies": {
+    "http-server": "^0.11.1"
   }
 }


### PR DESCRIPTION
- added heroku pre and post build scripts to temporarily set environment vars to development. This way the devDependencies will get installed.